### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,9 +19,9 @@ getApSsid	KEYWORD2
 setApCredentials	KEYWORD2
 handleWiFi	KEYWORD2
 setConnectNonBlock	KEYWORD2
-startApMode KEYWORD2
-onConnect KEYWORD2
-onAp  KEYWORD2
+startApMode	KEYWORD2
+onConnect	KEYWORD2
+onAp	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords