### PR TITLE
Adding Safer reset method for /wifi/rst path

### DIFF
--- a/PersWiFiManager.cpp
+++ b/PersWiFiManager.cpp
@@ -122,7 +122,11 @@ void PersWiFiManager::setupWiFiHandlers() {
   _server->on("/wifi/rst", [&]() {
     _server->send(200, "text/html", "Rebooting...");
     delay(100);
-    ESP.restart();
+    //ESP.restart();
+	// Adding Safer Restart method
+	ESP.wdtDisable();
+	ESP.reset();
+	delay(2000);
   });
 
 #ifdef WIFI_HTM_PROGMEM


### PR DESCRIPTION
**Issue**
There was an issue observed when the library is running in Async mode.
When the main / application Server api were accessed and then a Reset request was sent ESP8266 the system did not reset properly.

**Fix**
The fix in this commit would ensure a proper reset in most of the conditions.

**Where this was observed**
Example `spiffs_rest_api_nonblocking`