### PR TITLE
Remove WPS support

### DIFF
--- a/PersWiFiManager.cpp
+++ b/PersWiFiManager.cpp
@@ -6,7 +6,7 @@
 #include "PersWiFiManager.h"
 
 #ifdef WIFI_HTM_PROGMEM
-const char wifi_htm[] PROGMEM = R"=====(<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/><title>ESP WiFi</title><script>function g(i){return document.getElementById(i);};function p(t,l){if(confirm(t)) window.location=l;};function E(s){return document.createElement(s)};var S="setAttribute",A="appendChild",H="innerHTML",X,wl;function scan(){if(X) return;X=new XMLHttpRequest(),wl=document.getElementById('wl');wl[H]="Scanning...";X.onreadystatechange=function(){if (this.readyState==4&&this.status==200){X=0;wl[H]="";this.responseText.split("\n").forEach(function (e){let t=e.split(","), s=t.slice(2).join(',');var d=E('div'),i=E('a'),c=E('a');i[S]('class','s'); c[S]('class','q');i.onclick=function(){g('s').value=s;g('p').focus();};i[A](document.createTextNode(s));c[H]=t[0]+"%"+(parseInt(t[1])?"\uD83D\uDD12":"\u26A0");wl[A](i); wl[A](c);wl[A](document.createElement('br'));});}};X.open("GET","wifi/list",true);X.send();};</script><style>input{padding:5px;font-size:1em;width:95%;}body{text-align:center;font-family:verdana;background-color:black;color:white;}a{color:#1fa3ec;}button{border:0;border-radius:0.3em;background-color:#1fa3ec;color:#fff;line-height:2.4em;font-size:1.2em;width:100%;display:block;}.q{float:right;}.s{display:inline-block;width:14em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}#wl{line-height:1.5em;}</style></head><body><div style='text-align:left;display:inline-block;width:320px;padding:5px'><button onclick="scan()">&#x21bb; Scan</button><p id='wl'></p><form method='post' action='/wifi/connect'><input id='s' name='n' length=32 placeholder='SSID'><br><input id='p' name='p' length=64 type='password' placeholder='password'><br><br><button type='submit'>Connect</button></form><br><br><button onclick="p('Start WPS?','/wifi/wps')">WPS Setup</button><br><button onclick="p('Reboot device?','/wifi/rst')">Reboot</button><br><a href="javascript:history.back()">Back</a> |<a href="/">Home</a></div></body></html>)=====";
+const char wifi_htm[] PROGMEM = R"=====(<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/><title>ESP WiFi</title><script>function g(i){return document.getElementById(i);};function p(t,l){if(confirm(t)) window.location=l;};function E(s){return document.createElement(s)};var S="setAttribute",A="appendChild",H="innerHTML",X,wl;function scan(){if(X) return;X=new XMLHttpRequest(),wl=document.getElementById('wl');wl[H]="Scanning...";X.onreadystatechange=function(){if (this.readyState==4&&this.status==200){X=0;wl[H]="";this.responseText.split("\n").forEach(function (e){let t=e.split(","), s=t.slice(2).join(',');var d=E('div'),i=E('a'),c=E('a');i[S]('class','s'); c[S]('class','q');i.onclick=function(){g('s').value=s;g('p').focus();};i[A](document.createTextNode(s));c[H]=t[0]+"%"+(parseInt(t[1])?"\uD83D\uDD12":"\u26A0");wl[A](i); wl[A](c);wl[A](document.createElement('br'));});}};X.open("GET","wifi/list",true);X.send();};</script><style>input{padding:5px;font-size:1em;width:95%;}body{text-align:center;font-family:verdana;background-color:black;color:white;}a{color:#1fa3ec;}button{border:0;border-radius:0.3em;background-color:#1fa3ec;color:#fff;line-height:2.4em;font-size:1.2em;width:100%;display:block;}.q{float:right;}.s{display:inline-block;width:14em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}#wl{line-height:1.5em;}</style></head><body><div style='text-align:left;display:inline-block;width:320px;padding:5px'><button onclick="scan()">&#x21bb; Scan</button><p id='wl'></p><form method='post' action='/wifi/connect'><input id='s' name='n' length=32 placeholder='SSID'><br><input id='p' name='p' length=64 type='password' placeholder='password'><br><br><button type='submit'>Connect</button></form><br><br><button onclick="p('Reboot device?','/wifi/rst')">Reboot</button><br><a href="javascript:history.back()">Back</a> |<a href="/">Home</a></div></body></html>)=====";
 #endif
 
 PersWiFiManager::PersWiFiManager(ESP8266WebServer& s, DNSServer& d) {
@@ -98,16 +98,6 @@ void PersWiFiManager::setupWiFiHandlers() {
     //send string to client
     _server->send(200, "text/plain", s);
   }); //_server->on /wifi/list
-
-  _server->on("/wifi/wps", [&]() {
-    _server->send(200, "text/html", "attempting WPS");
-    WiFi.mode(WIFI_STA);
-    WiFi.beginWPSConfig();
-    delay(100);
-    if (WiFi.status() != WL_CONNECTED) {
-      attemptConnection("", "");
-    }
-  }); //_server->on /wifi/wps
 
   _server->on("/wifi/connect", [&]() {
     _server->send(200, "text/html", "connecting...");


### PR DESCRIPTION
Using WPS functions causes link errors since esp8266 library version 2.4.0:

```
/var/folders/9q/kc98p7l11fgctj4y1b8t344h0000gn/T/arduino_build_185922/libraries/PersWiFiManager/PersWiFiManager.cpp.o: In function `PersWiFiManager::attemptConnection(String const&, String const&)':
/Users/peter/code/arduino/libraries/PersWiFiManager/PersWiFiManager.cpp:30: undefined reference to `WPS_is_unavailable_in_this_configuration__Please_check_FAQ_or_board_generator_tool'
/var/folders/9q/kc98p7l11fgctj4y1b8t344h0000gn/T/arduino_build_185922/libraries/PersWiFiManager/PersWiFiManager.cpp.o:(.text._ZNSt17_Function_handlerIFvvEZN15PersWiFiManager17setupWiFiHandlersEvEUlvE0_E9_M_invokeERKSt9_Any_data+0x3e): undefined reference to `WPS_is_unavailable_in_this_configuration__Please_check_FAQ_or_board_generator_tool'
collect2: error: ld returned 1 exit status
```